### PR TITLE
refactor: update

### DIFF
--- a/speedcrunch.tera
+++ b/speedcrunch.tera
@@ -3,21 +3,21 @@ whiskers:
   version: "^2.9.0"
   matrix:
     - flavor
-  filename: "themes/catppuccin-{{flavor.identifier}}.json"
+  filename: "themes/catppuccin-{{ flavor.identifier }}.json"
+  hex_format: "#{{r}}{{g}}{{b}}{{z}}"
 ---
-{%- set palette = flavor.colors -%}
 {
-    "cursor": "#{{palette.rosewater.hex}}",
-    "number": "#{{palette.peach.hex}}",
-    "parens": "#{{palette.text.hex}}",
-    "result": "#{{palette.green.hex}}",
-    "comment": "#{{palette.overlay0.hex}}",
-    "matched": "#{{palette.teal.hex}}",
-    "function": "#{{palette.blue.hex}}",
-    "operator": "#{{palette.sky.hex}}",
-    "variable": "#{{palette.red.hex}}",
-    "scrollbar": "#{{palette.overlay2.hex}}",
-    "separator": "#{{palette.overlay2.hex}}",
-    "background": "#{{palette.base.hex}}",
-    "editorbackground": "#{{palette.surface0.hex}}"
+  "cursor": "{{ rosewater.hex }}",
+  "number": "{{ peach.hex }}",
+  "parens": "{{ text.hex }}",
+  "result": "{{ green.hex }}",
+  "comment": "{{ overlay0.hex }}",
+  "matched": "{{ teal.hex }}",
+  "function": "{{ blue.hex }}",
+  "operator": "{{ sky.hex }}",
+  "variable": "{{ red.hex }}",
+  "scrollbar": "{{ overlay2.hex }}",
+  "separator": "{{ overlay2.hex }}",
+  "background": "{{ base.hex }}",
+  "editorbackground": "{{ surface0.hex }}"
 }

--- a/speedcrunch.tera
+++ b/speedcrunch.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: 2.0.0
+  version: "^2.9.0"
   matrix:
     - flavor
   filename: "themes/catppuccin-{{flavor.identifier}}.json"

--- a/themes/catppuccin-frappe.json
+++ b/themes/catppuccin-frappe.json
@@ -1,15 +1,15 @@
 {
-    "cursor": "#f2d5cf",
-    "number": "#ef9f76",
-    "parens": "#c6d0f5",
-    "result": "#a6d189",
-    "comment": "#737994",
-    "matched": "#81c8be",
-    "function": "#8caaee",
-    "operator": "#99d1db",
-    "variable": "#e78284",
-    "scrollbar": "#949cbb",
-    "separator": "#949cbb",
-    "background": "#303446",
-    "editorbackground": "#414559"
+  "cursor": "#f2d5cf",
+  "number": "#ef9f76",
+  "parens": "#c6d0f5",
+  "result": "#a6d189",
+  "comment": "#737994",
+  "matched": "#81c8be",
+  "function": "#8caaee",
+  "operator": "#99d1db",
+  "variable": "#e78284",
+  "scrollbar": "#949cbb",
+  "separator": "#949cbb",
+  "background": "#303446",
+  "editorbackground": "#414559"
 }

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -1,15 +1,15 @@
 {
-    "cursor": "#dc8a78",
-    "number": "#fe640b",
-    "parens": "#4c4f69",
-    "result": "#40a02b",
-    "comment": "#9ca0b0",
-    "matched": "#179299",
-    "function": "#1e66f5",
-    "operator": "#04a5e5",
-    "variable": "#d20f39",
-    "scrollbar": "#7c7f93",
-    "separator": "#7c7f93",
-    "background": "#eff1f5",
-    "editorbackground": "#ccd0da"
+  "cursor": "#dc8a78",
+  "number": "#fe640b",
+  "parens": "#4c4f69",
+  "result": "#40a02b",
+  "comment": "#9ca0b0",
+  "matched": "#179299",
+  "function": "#1e66f5",
+  "operator": "#04a5e5",
+  "variable": "#d20f39",
+  "scrollbar": "#7c7f93",
+  "separator": "#7c7f93",
+  "background": "#eff1f5",
+  "editorbackground": "#ccd0da"
 }

--- a/themes/catppuccin-macchiato.json
+++ b/themes/catppuccin-macchiato.json
@@ -1,15 +1,15 @@
 {
-    "cursor": "#f4dbd6",
-    "number": "#f5a97f",
-    "parens": "#cad3f5",
-    "result": "#a6da95",
-    "comment": "#6e738d",
-    "matched": "#8bd5ca",
-    "function": "#8aadf4",
-    "operator": "#91d7e3",
-    "variable": "#ed8796",
-    "scrollbar": "#939ab7",
-    "separator": "#939ab7",
-    "background": "#24273a",
-    "editorbackground": "#363a4f"
+  "cursor": "#f4dbd6",
+  "number": "#f5a97f",
+  "parens": "#cad3f5",
+  "result": "#a6da95",
+  "comment": "#6e738d",
+  "matched": "#8bd5ca",
+  "function": "#8aadf4",
+  "operator": "#91d7e3",
+  "variable": "#ed8796",
+  "scrollbar": "#939ab7",
+  "separator": "#939ab7",
+  "background": "#24273a",
+  "editorbackground": "#363a4f"
 }

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -1,15 +1,15 @@
 {
-    "cursor": "#f5e0dc",
-    "number": "#fab387",
-    "parens": "#cdd6f4",
-    "result": "#a6e3a1",
-    "comment": "#6c7086",
-    "matched": "#94e2d5",
-    "function": "#89b4fa",
-    "operator": "#89dceb",
-    "variable": "#f38ba8",
-    "scrollbar": "#9399b2",
-    "separator": "#9399b2",
-    "background": "#1e1e2e",
-    "editorbackground": "#313244"
+  "cursor": "#f5e0dc",
+  "number": "#fab387",
+  "parens": "#cdd6f4",
+  "result": "#a6e3a1",
+  "comment": "#6c7086",
+  "matched": "#94e2d5",
+  "function": "#89b4fa",
+  "operator": "#89dceb",
+  "variable": "#f38ba8",
+  "scrollbar": "#9399b2",
+  "separator": "#9399b2",
+  "background": "#1e1e2e",
+  "editorbackground": "#313244"
 }


### PR DESCRIPTION
Bumps whiskers from `2.0.0` to `^2.9.0`.
Updates formatting/styling.
Uses `hex_format`.
Removes unnecessary setting of `{%- set palette = flavor.colors -%}` and `palette.` prefixes.